### PR TITLE
Encrypt #to_key so that generated HTML does not inadvertently expose unencrypted ID

### DIFF
--- a/lib/encrypted_id.rb
+++ b/lib/encrypted_id.rb
@@ -57,6 +57,14 @@ module EncryptedId
       EncryptedId.encrypt(self.class.encrypted_id_key, self.id)
     end
 
+    def to_key
+        key = self.id or nil
+        if key
+            key = [EncryptedId.encrypt(self.class.encrypted_id_key, self.id)]
+        end
+        key
+    end
+
     def reload(options = nil)
       options = (options || {}).merge(:no_encrypted_id => true)
       super(options)

--- a/spec/encrypted_id_spec.rb
+++ b/spec/encrypted_id_spec.rb
@@ -23,6 +23,11 @@ describe 'EncryptedId' do
         @entity.to_param.should == @test_ids[15]
       end
 
+      it 'should give us the encrypted ID (in array) via to_key' do
+        @entity.id = 15
+        @entity.to_key.should == [@test_ids[15]]
+      end
+
       it 'should be possible to find an entry by the encrypted id' do
         @entity.id = 8
         @entity.save!


### PR DESCRIPTION
This makes sure the `form_for` helper does not expose the unencrypted resource ID which otherwise will happen if to_key is not overridden.

Some background:

https://github.com/rails/rails/blob/3-2-13/actionpack/lib/action_view/helpers/form_helper.rb#L184-L201

https://github.com/rails/rails/blob/3-2-13/actionpack/lib/action_view/helpers/form_helper.rb#L391

http://apidock.com/rails/ActionController/RecordIdentifier/dom_id

http://apidock.com/rails/ActionController/RecordIdentifier/record_key_for_dom_id
